### PR TITLE
fix: require Remote ID before starting single drone broadcast

### DIFF
--- a/spoofer.py
+++ b/spoofer.py
@@ -1117,6 +1117,7 @@ document.getElementById('play').onclick=function(){
   }
   if(!pilotMarker)return alert('Set pilot location first.');
   if(path.length<2)return alert('Set at least 2 waypoints.');
+  if(!isOn('swarmEnabled')&&!document.getElementById('basicId').value.trim())return alert('Remote ID is required. Enter a drone identifier before starting.');
   missionState='playing';playing=true;
   var missionData={basic_id:document.getElementById('basicId').value,drone_altitude:parseInt(document.getElementById('alt').value)||0,path:path};
   fetch('/api/start',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(missionData)}).catch(console.error);


### PR DESCRIPTION
## Summary
- Single drone mode silently fails to transmit ODID beacons when Remote ID field is blank, because firmware `inject_odid()` early-returns on empty `basic_id`
- Added client-side validation alerting the user that Remote ID is required
- Swarm mode unaffected (auto-generates IDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)