### PR TITLE
feat: add M5Stack Stamp S3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **An OUI Spy firmware for WiFi-based FAA Remote ID spoofing and simulation.**
 
-Part of the [OUI Spy](https://github.com/colonelpanichacks) ecosystem -- built for the Seeed Studio XIAO ESP32-S3.
+Part of the [OUI Spy](https://github.com/colonelpanichacks) ecosystem -- built for the Seeed Studio XIAO ESP32-S3 and compatible ESP32-S3 boards (M5Stack Stamp S3).
 
 Inspired by [d0tslash](https://github.com/d0tslash) and **H.A.R.D** (Hackers Against Remote ID).
 
@@ -95,12 +95,13 @@ This project provides:
 |-------|------|------|--------|-----|
 | **Seeed XIAO ESP32-C5** | WiFi 6 | 2.4 + 5GHz | GPIO25 (D2) | GPIO27 (active HIGH) |
 | **Seeed XIAO ESP32-S3** | WiFi 4 | 2.4GHz only | GPIO3 (D2) | GPIO21 (active LOW) |
+| **M5Stack Stamp S3** | WiFi 4 | 2.4GHz only | GPIO1 (wire your own) | GPIO21 (SK6812 NeoPixel RGB) |
 
 Pin mapping and band capability auto-detected at compile time.
 
 ### Optional
-- Passive buzzer on D2 pin for audio feedback
-- Built-in LED for visual feedback
+- Passive buzzer on D2 pin for audio feedback (XIAO boards) or GPIO1 (M5Stack Stamp S3)
+- Built-in LED for visual feedback (NeoPixel RGB on M5Stack Stamp S3)
 
 ## Getting Started
 
@@ -116,9 +117,14 @@ Connect via USB and flash with PlatformIO:
 # ESP32-C5 (dual-band)
 pio run -e seeed_xiao_esp32c5 -t upload
 
-# ESP32-S3 (single-band)
+# ESP32-S3 — Seeed XIAO (single-band)
 pio run -e seeed_xiao_esp32s3 -t upload
+
+# ESP32-S3 — M5Stack Stamp S3 (single-band)
+pio run -e m5stack_stamps3 -t upload
 ```
+
+> **Note (M5Stack Stamp S3):** If the board is not detected, hold the **G0** button while plugging USB, then release to enter download mode. The Stamp S3 uses a built-in SK6812 NeoPixel RGB LED on GPIO21 (green flash on TX) and requires the Adafruit NeoPixel library (automatically pulled by PlatformIO).
 
 ### 3. Install Python Dependencies
 ```bash
@@ -177,7 +183,7 @@ Part of the [OUI Spy](https://github.com/colonelpanichacks/oui-spy) hardware & f
 | [OUI-SPY Foxhunter](https://github.com/colonelpanichacks/ouispy-foxhunter) | Precision BLE proximity tracker for radio direction finding | ESP32-S3 |
 | [Flock-You](https://github.com/colonelpanichacks/flock-you) | Flock Safety & Raven surveillance detector with GPS wardriving | ESP32-S3 |
 | [Sky Spy](https://github.com/colonelpanichacks/Sky-Spy) | Drone Remote ID detector — WiFi + BLE, multi-drone tracking | ESP32-S3 |
-| **Remote-ID-Spoofer** *(this repo)* | Remote ID spoofer & simulator with swarm mode | ESP32-S3 / ESP32-C5 |
+| **Remote-ID-Spoofer** *(this repo)* | Remote ID spoofer & simulator with swarm mode | ESP32-S3 / ESP32-C5 / M5Stack Stamp S3 |
 | [OUI-SPY UniPwn](https://github.com/colonelpanichacks/Oui-Spy-UniPwn) | Unitree robot BLE exploitation with AutoPwn and web UI | ESP32-S3 |
 
 ## Credits

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,3 +33,23 @@ monitor_speed = 115200
 
 lib_deps =
     bblanchon/ArduinoJson@^6.20.0
+
+; --- M5Stack Stamp S3 (single-band 2.4GHz) ---
+[env:m5stack_stamps3]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+board = m5stack-stamps3
+framework = arduino
+lib_ldf_mode = chain
+
+build_flags =
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DARDUINO_USB_MODE=1
+    -DCORE_DEBUG_LEVEL=0
+    -DM5STAMP_S3
+
+upload_speed = 921600
+monitor_speed = 115200
+
+lib_deps =
+    bblanchon/ArduinoJson@^6.20.0
+    adafruit/Adafruit NeoPixel@^1.12.0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,22 +9,45 @@
 #include "opendroneid.h"
 #include "odid_wifi.h"
 
+#if defined(M5STAMP_S3)
+  #include <Adafruit_NeoPixel.h>
+#endif
+
 // ── board auto-detect ──
 
 #if defined(ARDUINO_XIAO_ESP32C5)
-  #define BUZZER_PIN  25
-  #define LED_PIN     27
-  #define LED_ON      HIGH
-  #define LED_OFF     LOW
-  #define DUAL_BAND   true
-  #define BOARD_NAME  "XIAO ESP32-C5 (Dual-Band)"
+  #define BUZZER_PIN    25
+  #define LED_PIN       27
+  #define LED_ON        HIGH
+  #define LED_OFF       LOW
+  #define DUAL_BAND     true
+  #define USE_NEOPIXEL  false
+  #define BOARD_NAME    "XIAO ESP32-C5 (Dual-Band)"
+
+#elif defined(M5STAMP_S3)
+  // M5Stack Stamp S3: SK6812 RGB on GPIO21, buzzer on GPIO1 (wire your own)
+  #define NEOPIXEL_PIN  21
+  #define NEOPIXEL_NUM  1
+  #define BUZZER_PIN    1
+  #define LED_PIN       -1
+  #define LED_ON        LOW
+  #define LED_OFF       HIGH
+  #define DUAL_BAND     false
+  #define USE_NEOPIXEL  true
+  #define BOARD_NAME    "M5Stack Stamp S3 (2.4GHz)"
+
 #else
-  #define BUZZER_PIN  3
-  #define LED_PIN     21
-  #define LED_ON      LOW
-  #define LED_OFF     HIGH
-  #define DUAL_BAND   false
-  #define BOARD_NAME  "XIAO ESP32-S3 (2.4GHz)"
+  #define BUZZER_PIN    3
+  #define LED_PIN       21
+  #define LED_ON        LOW
+  #define LED_OFF       HIGH
+  #define DUAL_BAND     false
+  #define USE_NEOPIXEL  false
+  #define BOARD_NAME    "XIAO ESP32-S3 (2.4GHz)"
+#endif
+
+#if USE_NEOPIXEL
+  static Adafruit_NeoPixel neopixel(NEOPIXEL_NUM, NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
 #endif
 
 static const char*   BEACON_SSID     = "Starbucks WiFI";
@@ -39,6 +62,16 @@ static const uint8_t NUM_5G_CHANNELS = 5;
 // band mode: 0=2.4 only, 1=5GHz only, 2=dual
 static uint8_t g_band_mode = DUAL_BAND ? 2 : 0;
 static bool    g_5g_ch_enabled[5] = {true, true, true, true, true};
+
+// ── default config (edit these for standalone operation) ──
+// Set AUTOSTART to true to broadcast on boot without web UI
+#define AUTOSTART       false
+#define DEFAULT_ID      "FRAT0000000001"
+#define DEFAULT_LAT     48.8220        // drone start lat
+#define DEFAULT_LON     2.2700         // drone start lon
+#define DEFAULT_ALT     80             // altitude meters
+#define DEFAULT_PLAT    48.8215        // pilot lat
+#define DEFAULT_PLON    2.2695         // pilot lon
 
 static char    g_basic_id[ODID_ID_SIZE + 1] = "";
 static double  g_drone_lat  = 0.0;
@@ -102,6 +135,44 @@ static void heartbeatTick() {
 
 // ── LED ──
 
+#if USE_NEOPIXEL
+
+static void ledInit() {
+    neopixel.begin();
+    neopixel.setBrightness(30);
+    neopixel.clear();
+    neopixel.show();
+}
+
+static void ledOn() {
+    if (ledMuted) return;
+    neopixel.setPixelColor(0, neopixel.Color(0, 255, 0));  // green
+    neopixel.show();
+}
+
+static void ledOff() {
+    neopixel.clear();
+    neopixel.show();
+}
+
+static void ledFlash(int ms) {
+    if (ledMuted) return;
+    ledOn(); delay(ms); ledOff();
+}
+
+static void ledColor(uint8_t r, uint8_t g, uint8_t b) {
+    if (ledMuted) return;
+    neopixel.setPixelColor(0, neopixel.Color(r, g, b));
+    neopixel.show();
+}
+
+#else
+
+static void ledInit() {
+    pinMode(LED_PIN, OUTPUT);
+    ledOff();
+}
+
 static void ledOn()  { if (!ledMuted) digitalWrite(LED_PIN, LED_ON); }
 static void ledOff() { digitalWrite(LED_PIN, LED_OFF); }
 
@@ -109,6 +180,13 @@ static void ledFlash(int ms) {
     if (ledMuted) return;
     ledOn(); delay(ms); ledOff();
 }
+
+static void ledColor(uint8_t r, uint8_t g, uint8_t b) {
+    // simple LED: just on/off, ignore color
+    if (r || g || b) ledOn(); else ledOff();
+}
+
+#endif
 
 // ── ODID data builder ──
 
@@ -280,8 +358,7 @@ void setup() {
 
     pinMode(BUZZER_PIN, OUTPUT);
     digitalWrite(BUZZER_PIN, LOW);
-    pinMode(LED_PIN, OUTPUT);
-    ledOff();
+    ledInit();
 
     delay(300);
     playBootSound();
@@ -320,6 +397,23 @@ void setup() {
 
     ledFlash(100);
     Serial.println("Ready. Awaiting serial commands.\n");
+
+    #if AUTOSTART
+    strncpy(g_basic_id, DEFAULT_ID, ODID_ID_SIZE);
+    g_basic_id[ODID_ID_SIZE] = '\0';
+    g_drone_lat = DEFAULT_LAT;
+    g_drone_lon = DEFAULT_LON;
+    g_drone_alt = DEFAULT_ALT;
+    g_pilot_lat = DEFAULT_PLAT;
+    g_pilot_lon = DEFAULT_PLON;
+    g_has_data = true;
+    broadcastEnabled = true;
+    update_ap_ssid();
+    startBeep();
+    Serial.println("AUTOSTART: broadcasting with default config");
+    Serial.printf("  ID=%s lat=%.4f lon=%.4f alt=%d\n",
+                  g_basic_id, g_drone_lat, g_drone_lon, g_drone_alt);
+    #endif
 }
 
 void loop() {


### PR DESCRIPTION
- Add [env:m5stack_stamps3] to platformio.ini with USB CDC flags
- Add board auto-detect block for M5STAMP_S3 in main.cpp
- NeoPixel (SK6812) RGB LED on GPIO21 instead of simple GPIO
- Buzzer mapped to GPIO1 (optional, wire your own passive buzzer)
- Adafruit NeoPixel lib dependency for M5 env only
- Update README: hardware table, flash commands, notes
- No changes to existing XIAO S3/C5 behavior